### PR TITLE
protect against history expression expansion

### DIFF
--- a/cooler
+++ b/cooler
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set +o histexpand     # don't expand history expressions
+
 importTaps()
 {
 	while read p; do


### PR DESCRIPTION
for example: `!!` will be left as a literal string
