### PR TITLE
test $EUID instead of $UID

### DIFF
--- a/cooler
+++ b/cooler
@@ -106,7 +106,7 @@ elif [ "$1" = "import" ]
 			fi
 			if [ -s "$2/port.cr" -a ! "$3" = "--no-port" ]
 				then
-				if [[ "$UID" != 0 ]]; then
+				if [[ "$EUID" != 0 ]]; then
 				    echo "Administrator privileges are required to install MacPorts packages:"
 				    sudo -E cooler importPorts "$2"
 				fi


### PR DESCRIPTION
This is technically more correct in terms of the ability to
install macports. (Though in practice the user is unlikely to
encounter a scenario where `$UID` and `$EUID` differ.)
