### PR TITLE
exit script if any command fails with error code

### DIFF
--- a/cooler
+++ b/cooler
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+set -e                # exit on uncaught error
 set +o histexpand     # don't expand history expressions
 
 importTaps()


### PR DESCRIPTION
This setting is definitely best practice for scripting bash.
HOWEVER, unlike #2 this is not a simple safety rail.  It
may be that merging this causes the script to fail because
there are unaccounted errors.
